### PR TITLE
Add scihub-manuscript-es to catalog

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -16,6 +16,9 @@
   thumbnail_url: https://raw.githubusercontent.com/greenelab/scihub-manuscript/master/thumbnail.png
   preprint_citation: doi:10.7287/peerj.preprints.3100
   journal_citation: doi:10.7554/eLife.32822
+- repo_url: https://github.com/greenelab/scihub-manuscript-es
+  html_url: https://greenelab.github.io/scihub-manuscript-es/
+  thumbnail_url: https://raw.githubusercontent.com/greenelab/scihub-manuscript/master/thumbnail.png
 - repo_url: https://github.com/simonvh/gimmemotifs-manuscript
   html_url: https://simonvh.github.io/gimmemotifs-manuscript/
   preprint_citation: doi:10.1101/474403


### PR DESCRIPTION
https://twitter.com/humbertodebat/status/1173622699387707392

We haven't had a translation of an existing catalog manuscript before. I think given the current catalog implementation, it makes sense to list this a separate manuscript. I used the thumbnail from the english manuscript repo.