### PR TITLE
Add "Extension of Roles in the ChEBI Ontology"

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -118,3 +118,5 @@
   html_url: https://mangul-lab-usc.github.io/enhancing_reproducibility/
   preprint_citation: arxiv:2001.05127
   journal_citation: doi:10.1093/gigascience/giaa056
+- repo_url: https://github.com/chemical-roles/manuscript
+  html_url: https://chemical-roles.github.io/manuscript/


### PR DESCRIPTION
This PR adds the GitHub repository https://github.com/chemical-roles/manuscript for "Extension of Roles in the ChEBI Ontology"