### PR TITLE
Add deep rules preprint

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -24,7 +24,7 @@
   preprint_citation: doi:10.6084/m9.figshare.5346577
 - repo_url: https://github.com/Benjamin-Lee/deep-rules
   html_url: https://benjamin-lee.github.io/deep-rules/
-  thumbnail_url: https://user-images.githubusercontent.com/8326331/64824922-7e6fc200-d589-11e9-8df1-2673996cce9b.png
+  preprint_citation: arxiv:2105.14372
 - repo_url: https://github.com/zietzm/integration-review
   html_url: https://zietzm.github.io/integration-review/
 - repo_url: https://github.com/dhimmel/rephetio-manuscript/


### PR DESCRIPTION
I removed the thumbnail URL because there is now a thumbnail in the repository.