### PR TITLE
journal_citation for iscb-diversity-manuscript

### DIFF
--- a/catalog.yml
+++ b/catalog.yml
@@ -99,6 +99,7 @@
 - repo_url: https://github.com/greenelab/iscb-diversity-manuscript
   html_url: https://greenelab.github.io/iscb-diversity-manuscript/
   preprint_citation: doi:10.1101/2020.04.14.927251
+  journal_citation: doi:10.1016/j.cels.2021.07.007
 - repo_url: https://github.com/greenelab/covid19-review
   html_url: https://greenelab.github.io/covid19-review/
 - repo_url: https://github.com/fmaguire/mag_sim_paper


### PR DESCRIPTION
https://doi.org/10.1016/j.cels.2021.07.007

looks like Crossref metadata hasn't been published yet, so wait to merge.