### PR TITLE
Enable manual references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ An example manuscript with documentation comments is below:
 
 For more information on how to create citations for `preprint_citation` and `journal_citation`, see Manubot's citation-by-identifier [documentation here](https://github.com/manubot/rootstock/blob/main/USAGE.md#citations).
 Specifying `thumbnail_url` overrides the thumbnail image detected from the metadata of `html_url`.
-Therefore, setting `thumbnail_url` is only neccessary if the manuscript does not supply a thumbnail image or if the catalog should use a different image.
+Therefore, setting `thumbnail_url` is only necessary if the manuscript does not supply a thumbnail image or if the catalog should use a different image.
+
+If Manubot has trouble generating the CSL Data for a citation,
+which could happen due to upstream issues [like this one](https://github.com/crosscite/content-negotiation/issues/104),
+add the reference to [`bibliography.yaml`](bibliography.yaml).
 
 ## Thumbnail Guidelines
 

--- a/bibliography.yaml
+++ b/bibliography.yaml
@@ -1,0 +1,366 @@
+- id: doi:10.7287/peerj.preprints.3100
+  type: report
+  title: Sci-Hub provides access to nearly all scholarly literature
+  language: en
+  number: e3100v3
+  publisher: PeerJ Preprints
+  URL: https://peerj.com/preprints/3100
+  DOI: 10.7287/peerj.preprints.3100
+  author:
+  - family: Himmelstein
+    given: Daniel S.
+  - family: Romero
+    given: Ariel R.
+  - family: Levernier
+    given: Jacob G.
+  - family: Munro
+    given: Thomas A.
+  - family: McLaughlin
+    given: Stephen R.
+  - family: Tzovaras
+    given: Bastian Greshake
+  - family: Greene
+    given: Casey S.
+  issued:
+    date-parts:
+    - - 2018
+      - 2
+      - 2
+- id: doi:10.1111/geb.13346
+  type: article-journal
+  title: sPlotOpen – An environmentally balanced, open‐access, global dataset of vegetation plots
+  author:
+  - family: Sabatini
+    given: Francesco Maria
+  - family: Lenoir
+    given: Jonathan
+  - family: Hattab
+    given: Tarek
+  - family: Arnst
+    given: Elise Aimee
+  - family: Chytrý
+    given: Milan
+  - family: Dengler
+    given: Jürgen
+  - family: De Ruffray
+    given: Patrice
+  - family: Hennekens
+    given: Stephan M.
+  - family: Jandt
+    given: Ute
+  - family: Jansen
+    given: Florian
+  - family: Jiménez‐Alfaro
+    given: Borja
+  - family: Kattge
+    given: Jens
+  - family: Levesley
+    given: Aurora
+  - family: Pillar
+    given: Valério D.
+  - family: Purschke
+    given: Oliver
+  - family: Sandel
+    given: Brody
+  - family: Sultana
+    given: Fahmida
+  - family: Aavik
+    given: Tsipe
+  - family: Aćić
+    given: Svetlana
+  - family: Acosta
+    given: Alicia T. R.
+  - family: Agrillo
+    given: Emiliano
+  - family: Alvarez
+    given: Miguel
+  - family: Apostolova
+    given: Iva
+  - family: Arfin Khan
+    given: Mohammed A. S.
+  - family: Arroyo
+    given: Luzmila
+  - family: Attorre
+    given: Fabio
+  - family: Aubin
+    given: Isabelle
+  - family: Banerjee
+    given: Arindam
+  - family: Bauters
+    given: Marijn
+  - family: Bergeron
+    given: Yves
+  - family: Bergmeier
+    given: Erwin
+  - family: Biurrun
+    given: Idoia
+  - family: Bjorkman
+    given: Anne D.
+  - family: Bonari
+    given: Gianmaria
+  - family: Bondareva
+    given: Viktoria
+  - family: Brunet
+    given: Jörg
+  - family: Čarni
+    given: Andraž
+  - family: Casella
+    given: Laura
+  - family: Cayuela
+    given: Luis
+  - family: Černý
+    given: Tomáš
+  - family: Chepinoga
+    given: Victor
+  - family: Csiky
+    given: János
+  - family: Ćušterevska
+    given: Renata
+  - family: De Bie
+    given: Els
+  - family: Gasper
+    given: André Luis
+  - family: De Sanctis
+    given: Michele
+  - family: Dimopoulos
+    given: Panayotis
+  - family: Dolezal
+    given: Jiri
+  - family: Dziuba
+    given: Tetiana
+  - family: El‐Sheikh
+    given: Mohamed Abd El‐Rouf Mousa
+  - family: Enquist
+    given: Brian
+  - family: Ewald
+    given: Jörg
+  - family: Fazayeli
+    given: Farideh
+  - family: Field
+    given: Richard
+  - family: Finckh
+    given: Manfred
+  - family: Gachet
+    given: Sophie
+  - family: Galán‐de‐Mera
+    given: Antonio
+  - family: Garbolino
+    given: Emmanuel
+  - family: Gholizadeh
+    given: Hamid
+  - family: Giorgis
+    given: Melisa
+  - family: Golub
+    given: Valentin
+  - family: Alsos
+    given: Inger Greve
+  - family: Grytnes
+    given: John‐Arvid
+  - family: Guerin
+    given: Gregory Richard
+  - family: Gutiérrez
+    given: Alvaro G.
+  - family: Haider
+    given: Sylvia
+  - family: Hatim
+    given: Mohamed Z.
+  - family: Hérault
+    given: Bruno
+  - family: Hinojos Mendoza
+    given: Guillermo
+  - family: Hölzel
+    given: Norbert
+  - family: Homeier
+    given: Jürgen
+  - family: Hubau
+    given: Wannes
+  - family: Indreica
+    given: Adrian
+  - family: Janssen
+    given: John A. M.
+  - family: Jedrzejek
+    given: Birgit
+  - family: Jentsch
+    given: Anke
+  - family: Jürgens
+    given: Norbert
+  - family: Kącki
+    given: Zygmunt
+  - family: Kapfer
+    given: Jutta
+  - family: Karger
+    given: Dirk Nikolaus
+  - family: Kavgacı
+    given: Ali
+  - family: Kearsley
+    given: Elizabeth
+  - family: Kessler
+    given: Michael
+  - family: Khanina
+    given: Larisa
+  - family: Killeen
+    given: Timothy
+  - family: Korolyuk
+    given: Andrey
+  - family: Kreft
+    given: Holger
+  - family: Kühl
+    given: Hjalmar S.
+  - family: Kuzemko
+    given: Anna
+  - family: Landucci
+    given: Flavia
+  - family: Lengyel
+    given: Attila
+  - family: Lens
+    given: Frederic
+  - family: Lingner
+    given: Débora Vanessa
+  - family: Liu
+    given: Hongyan
+  - family: Lysenko
+    given: Tatiana
+  - family: Mahecha
+    given: Miguel D.
+  - family: Marcenò
+    given: Corrado
+  - family: Martynenko
+    given: Vasiliy
+  - family: Moeslund
+    given: Jesper Erenskjold
+  - family: Monteagudo Mendoza
+    given: Abel
+  - family: Mucina
+    given: Ladislav
+  - family: Müller
+    given: Jonas V.
+  - family: Munzinger
+    given: Jérôme
+  - family: Naqinezhad
+    given: Alireza
+  - family: Noroozi
+    given: Jalil
+  - family: Nowak
+    given: Arkadiusz
+  - family: Onyshchenko
+    given: Viktor
+  - family: Overbeck
+    given: Gerhard E.
+  - family: Pärtel
+    given: Meelis
+  - family: Pauchard
+    given: Aníbal
+  - family: Peet
+    given: Robert K.
+  - family: Peñuelas
+    given: Josep
+  - family: Pérez‐Haase
+    given: Aaron
+  - family: Peterka
+    given: Tomáš
+  - family: Petřík
+    given: Petr
+  - family: Peyre
+    given: Gwendolyn
+  - family: Phillips
+    given: Oliver L.
+  - family: Prokhorov
+    given: Vadim
+  - family: Rašomavičius
+    given: Valerijus
+  - family: Revermann
+    given: Rasmus
+  - family: Rivas‐Torres
+    given: Gonzalo
+  - family: Rodwell
+    given: John S.
+  - family: Ruprecht
+    given: Eszter
+  - family: Rūsiņa
+    given: Solvita
+  - family: Samimi
+    given: Cyrus
+  - family: Schmidt
+    given: Marco
+  - family: Schrodt
+    given: Franziska
+  - family: Shan
+    given: Hanhuai
+  - family: Shirokikh
+    given: Pavel
+  - family: Šibík
+    given: Jozef
+  - family: Šilc
+    given: Urban
+  - family: Sklenář
+    given: Petr
+  - family: Škvorc
+    given: Željko
+  - family: Sparrow
+    given: Ben
+  - family: Sperandii
+    given: Marta Gaia
+  - family: Stančić
+    given: Zvjezdana
+  - family: Svenning
+    given: Jens‐Christian
+  - family: Tang
+    given: Zhiyao
+  - family: Tang
+    given: Cindy Q.
+  - family: Tsiripidis
+    given: Ioannis
+  - family: Vanselow
+    given: Kim André
+  - family: Vásquez Martínez
+    given: Rodolfo
+  - family: Vassilev
+    given: Kiril
+  - family: Vélez‐Martin
+    given: Eduardo
+  - family: Venanzoni
+    given: Roberto
+  - family: Vibrans
+    given: Alexander Christian
+  - family: Violle
+    given: Cyrille
+  - family: Virtanen
+    given: Risto
+  - family: Wehrden
+    given: Henrik
+  - family: Wagner
+    given: Viktoria
+  - family: Walker
+    given: Donald A.
+  - family: Waller
+    given: Donald M.
+  - family: Wang
+    given: Hua‐Feng
+  - family: Wesche
+    given: Karsten
+  - family: Whitfeld
+    given: Timothy J. S.
+  - family: Willner
+    given: Wolfgang
+  - family: Wiser
+    given: Susan K.
+  - family: Wohlgemuth
+    given: Thomas
+  - family: Yamalov
+    given: Sergey
+  - family: Zobel
+    given: Martin
+  - family: Bruelheide
+    given: Helge
+  - family: Bates
+    given: Amanda
+  issued:
+    date-parts:
+      - - 2021
+        - 6
+        - 21
+  container-title: Global Ecology and Biogeography
+  DOI: 10.1111/geb.13346
+  page: geb.13346
+  publisher: Wiley
+  URL: 'https://doi.org/gkzwjv'

--- a/catalog.yml
+++ b/catalog.yml
@@ -14,8 +14,7 @@
 - repo_url: https://github.com/greenelab/scihub-manuscript
   html_url: https://greenelab.github.io/scihub-manuscript/
   # https://github.com/crosscite/content-negotiation/issues/104
-  # preprint_citation: doi:10.7287/peerj.preprints.3100
-  preprint_citation: https://doi.org/10.7287/peerj.preprints.3100
+  preprint_citation: doi:10.7287/peerj.preprints.3100
   journal_citation: doi:10.7554/eLife.32822
 - repo_url: https://github.com/greenelab/scihub-manuscript-es
   html_url: https://greenelab.github.io/scihub-manuscript-es/
@@ -175,8 +174,7 @@
 - repo_url: https://github.com/fmsabatini/sPlotOpen_Manuscript
   html_url: https://fmsabatini.github.io/sPlotOpen_Manuscript/
   # https://github.com/crosscite/content-negotiation/issues/104
-  # journal_citation: doi:10.1111/geb.13346
-  journal_citation: https://doi.org/10.1111/geb.13346
+  journal_citation: doi:10.1111/geb.13346
 - repo_url: https://github.com/greenelab/phenoplier_manuscript
   html_url: https://greenelab.github.io/phenoplier_manuscript/
   preprint_citation: doi:10.1101/2021.07.05.450786

--- a/process-catalog.py
+++ b/process-catalog.py
@@ -5,14 +5,17 @@ import pathlib
 import requests
 import yaml
 from manubot.cite.citekey import citekey_to_csl_item, CiteKey
+from manubot.process.bibliography import load_manual_references
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 directory = pathlib.Path(__file__).parent
 with directory.joinpath("catalog.yml").open() as read_file:
     input_catalog = yaml.safe_load(read_file)
-logging.info(f"catalog consists of {len(input_catalog):,} records")
+logging.info(f"Catalog consists of {len(input_catalog):,} records.")
 
+manual_references = load_manual_references(paths = [directory.joinpath("bibliography.yaml")])
+logging.info(f"Loaded {len(manual_references):,} manual references.")
 
 def get_journal(csl_item):
     keys = [
@@ -165,7 +168,7 @@ def process_record(record):
             "citation": citekey.standard_id,
         }
     for item in output.values():
-        csl_item = citekey_to_csl_item(item["citation"])
+        csl_item = citekey_to_csl_item(item["citation"], manual_refs=manual_references)
         if "url" not in item and "URL" in csl_item:
             item["url"] = csl_item["URL"]
         item["title"] = get_title(csl_item)


### PR DESCRIPTION
This will help us with issues like https://github.com/crosscite/content-negotiation/issues/104. We also could add additional references to speed up CI, although perhaps that should be a separate cache file.